### PR TITLE
Move test code to the same package as the main code

### DIFF
--- a/test/com/tvl/util/BadHasher.java
+++ b/test/com/tvl/util/BadHasher.java
@@ -1,8 +1,5 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-package com.tvl.util.test;
-
-import com.tvl.util.EqualityComparator;
-import com.tvl.util.EqualityComparators;
+package com.tvl.util;
 
 class BadHasher<T> implements EqualityComparator<T> {
 

--- a/test/com/tvl/util/EverythingEqual.java
+++ b/test/com/tvl/util/EverythingEqual.java
@@ -1,7 +1,5 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-package com.tvl.util.test;
-
-import com.tvl.util.EqualityComparator;
+package com.tvl.util;
 
 class EverythingEqual<T> implements EqualityComparator<T> {
 

--- a/test/com/tvl/util/GenericParameterHelper.java
+++ b/test/com/tvl/util/GenericParameterHelper.java
@@ -1,5 +1,5 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-package com.tvl.util.test;
+package com.tvl.util;
 
 import java.util.Random;
 

--- a/test/com/tvl/util/ImmutableArrayBuilderTest.java
+++ b/test/com/tvl/util/ImmutableArrayBuilderTest.java
@@ -1,8 +1,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-package com.tvl.util.test;
+package com.tvl.util;
 
 import com.google.common.collect.Iterables;
-import com.tvl.util.ImmutableArrayList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;

--- a/test/com/tvl/util/ImmutableLinkedQueueTest.java
+++ b/test/com/tvl/util/ImmutableLinkedQueueTest.java
@@ -1,9 +1,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-package com.tvl.util.test;
+package com.tvl.util;
 
 import com.google.common.collect.Iterables;
-import com.tvl.util.ImmutableLinkedQueue;
-import com.tvl.util.ImmutableQueue;
 import java.util.Arrays;
 import java.util.EmptyStackException;
 import java.util.Iterator;

--- a/test/com/tvl/util/ImmutableLinkedStackTest.java
+++ b/test/com/tvl/util/ImmutableLinkedStackTest.java
@@ -1,9 +1,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-package com.tvl.util.test;
+package com.tvl.util;
 
 import com.google.common.collect.Iterables;
-import com.tvl.util.ImmutableLinkedStack;
-import com.tvl.util.ImmutableStack;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EmptyStackException;

--- a/test/com/tvl/util/ImmutablesTestBase.java
+++ b/test/com/tvl/util/ImmutablesTestBase.java
@@ -1,5 +1,5 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-package com.tvl.util.test;
+package com.tvl.util;
 
 import com.google.common.collect.Iterables;
 import java.text.Collator;

--- a/test/com/tvl/util/SimpleElementImmutablesTestBase.java
+++ b/test/com/tvl/util/SimpleElementImmutablesTestBase.java
@@ -1,5 +1,5 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-package com.tvl.util.test;
+package com.tvl.util;
 
 import com.google.common.collect.Iterables;
 


### PR DESCRIPTION
This allows package-private types and members to be tested.
